### PR TITLE
#229 Исправила сохранение файлов

### DIFF
--- a/Ask.Engine/ControlCommandAnalyser/Parser/Pr/PrCommandParser.cs
+++ b/Ask.Engine/ControlCommandAnalyser/Parser/Pr/PrCommandParser.cs
@@ -228,7 +228,7 @@ namespace Ask.Engine.ControlCommandAnalyser.Parser.Pr
         model.Errors.Add(PrErrors.EmptyPoints(model.StartLineNumber, $"{model.CommandNumber}   {model.Mnemonic}"));
       }
 
-      if (!string.IsNullOrEmpty(remainder))
+      if (!string.IsNullOrEmpty(remainder)&&!string.IsNullOrWhiteSpace(remainder))
       {
         model.UnparsedParameters = "! Не распознанные параметры: ";
         model.UnparsedParameters += remainder;

--- a/MainWindow/Services/FileService.cs
+++ b/MainWindow/Services/FileService.cs
@@ -84,7 +84,7 @@ namespace MainWindowProgram.Services
       {
         OpenFileDialog openFileDialog = new OpenFileDialog
         {
-          Filter = "PK files (*.pk, *.Pk, *.PK)|*.pk; *.Pk; *.PK|ACS files (*.ACS, *.Acs, *.acs)|*.ACS; *.Acs; *.ACs; *.AcS; *.aCS; *.acs|Text files (*.txt)|*.txt|All files (*.*)|*.*",
+          Filter = "PKW files (*.pkw, *.Pkw, *.PKW)|*.pkw; *.Pkw; *.PKW|PK files (*.pk, *.Pk, *.PK)|*.pk; *.Pk; *.PK|ACS files (*.ACS, *.Acs, *.acs)|*.ACS; *.Acs; *.ACs; *.AcS; *.aCS; *.acs|Text files (*.txt)|*.txt|All files (*.*)|*.*",
           Title = "Выберите файл",
         };
 

--- a/UI/Components/MultiEditorMethods/SaveFileManager.cs
+++ b/UI/Components/MultiEditorMethods/SaveFileManager.cs
@@ -139,7 +139,7 @@ namespace UI.Components.MultiEditorMethods
     {
       var saveFileDialog = new SaveFileDialog
       {
-        Filter = "Файлы программ контроля (*.pk, *.PK, *.Pk)|*.pk;*.PK;*.Pk|Текстовые файлы (*.txt)|*.txt",
+        Filter = "Файлы программ контроля (*.pkw, *.PKW, *.Pkw)|*.pkw;*.PKW;*.Pkw|Текстовые файлы (*.txt)|*.txt",
         Title = "Сохранить файл как",
         FileName = GetActiveTabName(),
       };
@@ -208,15 +208,16 @@ namespace UI.Components.MultiEditorMethods
     private bool SaveDataFromTextEditor(TextEditorUI textEditor, string filePath)
     {
       var fileData = textEditor.Text;
-      if (filePath.ToLower().Contains(".pk") && !filePath.ToLower().Contains(".pkw"))
+      if (filePath.ToLower().EndsWith(".pkw") || filePath.ToLower().EndsWith(".txt"))
+      {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        File.WriteAllText(filePath, fileData, Encoding.UTF8);
+      }
+      else 
       {
         var encoding = textEditor.TextEditorModel.Encoding;
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         File.WriteAllText(filePath, fileData, encoding == null ? Encoding.GetEncoding(866) : encoding);
-      }
-      else
-      {
-        File.WriteAllText(filePath, fileData);
       }
       LogInformation($"Файл {filePath} сохранен");
       MessageBoxCustom.Show($"Файл {filePath} сохранен", image: MessageBoxImage.Information);

--- a/UI/Services/EncodingService.cs
+++ b/UI/Services/EncodingService.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Text;
+using System.Text.Unicode;
 using Ude;
 
 namespace Utilities.Services
@@ -59,11 +60,12 @@ namespace Utilities.Services
       {
         try
         {
-          return Encoding.GetEncoding(detector.Charset);
+          var enc = Encoding.GetEncoding(detector.Charset);
+          return enc; 
         }
         catch
         {
-          return Encoding.UTF8;
+          return Encoding.GetEncoding(866);
         }
       }
 

--- a/UI/Services/FileManager/FileOpenService.cs
+++ b/UI/Services/FileManager/FileOpenService.cs
@@ -166,7 +166,17 @@ namespace UI.Services.FileManager
     internal (string, Encoding) ReadFileContent(string path)
     {
       Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-      var encoding = EncodingService.DetectEncodingFromFile(path);
+      //var encoding = EncodingService.DetectEncodingFromFile(path);
+      var extention = Path.GetExtension(path).ToLowerInvariant();
+      Encoding encoding;
+      if (extention == ".pkw" || extention == ".txt")
+      {
+        encoding = Encoding.UTF8;
+      }
+      else
+      {
+        encoding = Encoding.GetEncoding(866);
+      }
 
       var lines = File.ReadLines(path, encoding)
                       .Where(line => !string.IsNullOrEmpty(line))


### PR DESCRIPTION
- новые файлы теперь сохраняем только как pkw или txt
- для файлов .pkw и txt принудительно считываем в кодировке utf-8, для всех остальных в 866, больше это не делается автоматически
- при сохранении pkw и txt файлы записываются в utf8, остальные либо  в 866, либо в другой заданной кодировке